### PR TITLE
specify solc version

### DIFF
--- a/truffle.js
+++ b/truffle.js
@@ -7,5 +7,10 @@ module.exports = {
       gas: 4000000,
       gasPrice: 10000000000, // 10 gwei
     }
+  },
+  compilers: {
+     solc: {
+       version: "0.4.15"
+     }
   }
 };


### PR DESCRIPTION
In order to have a clean build, I downgrade the solc version from 0.5.0 (that is the one used in our organization) to the one of Gnosis.

Please approve if you don't see any downside.